### PR TITLE
Update to Guava 23

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ import org.gradle.api.artifacts.maven.MavenDeployment
 ext {
     project_group = 'tech.huffman.re-retrying'
     project_version = '3.0.0-SNAPSHOT'
-    project_jdk = '1.6'
+    project_jdk = '1.8'
     project_pom = {
         name 're-retrying'
         packaging 'jar'
@@ -108,7 +108,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:20.0'
+    compile 'com.google.guava:guava:23.0'
     compile 'com.google.code.findbugs:jsr305:2.0.2'
 
     // junit testing

--- a/src/main/java/com/github/rholder/retry/AttemptTimeLimiters.java
+++ b/src/main/java/com/github/rholder/retry/AttemptTimeLimiters.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012-2015 Ray Holder
+ * Modifications copyright 2017 Robert Huffman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +25,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -87,11 +89,11 @@ public class AttemptTimeLimiters {
         private final TimeUnit timeUnit;
 
         public FixedAttemptTimeLimit(long duration, @Nonnull TimeUnit timeUnit) {
-            this(new SimpleTimeLimiter(), duration, timeUnit);
+            this(duration, timeUnit, Executors.newCachedThreadPool());
         }
 
         public FixedAttemptTimeLimit(long duration, @Nonnull TimeUnit timeUnit, @Nonnull ExecutorService executorService) {
-            this(new SimpleTimeLimiter(executorService), duration, timeUnit);
+            this(SimpleTimeLimiter.create(executorService), duration, timeUnit);
         }
 
         private FixedAttemptTimeLimit(@Nonnull TimeLimiter timeLimiter, long duration, @Nonnull TimeUnit timeUnit) {
@@ -104,7 +106,7 @@ public class AttemptTimeLimiters {
 
         @Override
         public V call(Callable<V> callable) throws Exception {
-            return timeLimiter.callWithTimeout(callable, duration, timeUnit, true);
+            return timeLimiter.callWithTimeout(callable, duration, timeUnit);
         }
     }
 }

--- a/src/test/java/com/github/rholder/retry/AttemptTimeLimiterTest.java
+++ b/src/test/java/com/github/rholder/retry/AttemptTimeLimiterTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012-2015 Ray Holder
+ * Modifications copyright 2017 Robert Huffman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +17,13 @@
 
 package com.github.rholder.retry;
 
-import com.google.common.util.concurrent.UncheckedTimeoutException;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * @author Jason Dunkelberger (dirkraft)
@@ -46,7 +47,7 @@ public class AttemptTimeLimiterTest {
             Assert.fail("Expected timeout exception");
         } catch (ExecutionException e) {
             // expected
-            Assert.assertEquals(UncheckedTimeoutException.class, e.getCause().getClass());
+            Assert.assertEquals(TimeoutException.class, e.getCause().getClass());
         }
     }
 


### PR DESCRIPTION
== DETAILS

Updating to Guava 23 requires updating the target compatibility to
Java 8. Otherwise, the changes are minor.

There is a small change in behavior. When a Retryer is built with a
TimeLimiter, timeout causes an ExecutionException to be thrown. In
previous versions, the cause of that exception was an instance of
com.google.common.util.concurrent.UncheckedTimeoutException.  Now it
is an instance of java.util.concurrent.TimeoutException.

Fixes #8 