### PR TITLE
Modernize code

### DIFF
--- a/src/main/java/com/github/rholder/retry/Attempt.java
+++ b/src/main/java/com/github/rholder/retry/Attempt.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012-2015 Ray Holder
+ * Modifications copyright 2017 Robert Huffman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +35,7 @@ public interface Attempt<V> {
      * @throws ExecutionException if an exception was thrown by the attempt. The thrown
      *                            exception is set as the cause of the ExecutionException
      */
-    public V get() throws ExecutionException;
+    V get() throws ExecutionException;
 
     /**
      * Tells if the call returned a result or not
@@ -42,7 +43,7 @@ public interface Attempt<V> {
      * @return <code>true</code> if the call returned a result, <code>false</code>
      *         if it threw an exception
      */
-    public boolean hasResult();
+    boolean hasResult();
 
     /**
      * Tells if the call threw an exception or not
@@ -50,7 +51,7 @@ public interface Attempt<V> {
      * @return <code>true</code> if the call threw an exception, <code>false</code>
      *         if it returned a result
      */
-    public boolean hasException();
+    boolean hasException();
 
     /**
      * Gets the result of the call
@@ -59,7 +60,7 @@ public interface Attempt<V> {
      * @throws IllegalStateException if the call didn't return a result, but threw an exception,
      *                               as indicated by {@link #hasResult()}
      */
-    public V getResult() throws IllegalStateException;
+    V getResult() throws IllegalStateException;
 
     /**
      * Gets the exception thrown by the call
@@ -68,19 +69,19 @@ public interface Attempt<V> {
      * @throws IllegalStateException if the call didn't throw an exception,
      *                               as indicated by {@link #hasException()}
      */
-    public Throwable getExceptionCause() throws IllegalStateException;
+    Throwable getExceptionCause() throws IllegalStateException;
 
     /**
      * The number, starting from 1, of this attempt.
      *
      * @return the attempt number
      */
-    public long getAttemptNumber();
+    long getAttemptNumber();
 
     /**
      * The delay since the start of the first attempt, in milliseconds.
      *
      * @return the delay since the start of the first attempt, in milliseconds
      */
-    public long getDelaySinceFirstAttempt();
+    long getDelaySinceFirstAttempt();
 }

--- a/src/main/java/com/github/rholder/retry/AttemptTimeLimiters.java
+++ b/src/main/java/com/github/rholder/retry/AttemptTimeLimiters.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Jason Dunkelberger (dirkraft)
  */
+@SuppressWarnings("WeakerAccess")
 public class AttemptTimeLimiters {
 
     private AttemptTimeLimiters() {
@@ -43,7 +44,7 @@ public class AttemptTimeLimiters {
      * @return an {@link AttemptTimeLimiter} impl which has no time limit
      */
     public static <V> AttemptTimeLimiter<V> noTimeLimit() {
-        return new NoAttemptTimeLimit<V>();
+        return new NoAttemptTimeLimit<>();
     }
 
     /**
@@ -58,7 +59,7 @@ public class AttemptTimeLimiters {
      */
     public static <V> AttemptTimeLimiter<V> fixedTimeLimit(long duration, @Nonnull TimeUnit timeUnit) {
         Preconditions.checkNotNull(timeUnit);
-        return new FixedAttemptTimeLimit<V>(duration, timeUnit);
+        return new FixedAttemptTimeLimit<>(duration, timeUnit);
     }
 
     /**
@@ -70,7 +71,7 @@ public class AttemptTimeLimiters {
      */
     public static <V> AttemptTimeLimiter<V> fixedTimeLimit(long duration, @Nonnull TimeUnit timeUnit, @Nonnull ExecutorService executorService) {
         Preconditions.checkNotNull(timeUnit);
-        return new FixedAttemptTimeLimit<V>(duration, timeUnit, executorService);
+        return new FixedAttemptTimeLimit<>(duration, timeUnit, executorService);
     }
 
     @Immutable
@@ -88,11 +89,11 @@ public class AttemptTimeLimiters {
         private final long duration;
         private final TimeUnit timeUnit;
 
-        public FixedAttemptTimeLimit(long duration, @Nonnull TimeUnit timeUnit) {
+        FixedAttemptTimeLimit(long duration, @Nonnull TimeUnit timeUnit) {
             this(duration, timeUnit, Executors.newCachedThreadPool());
         }
 
-        public FixedAttemptTimeLimit(long duration, @Nonnull TimeUnit timeUnit, @Nonnull ExecutorService executorService) {
+        FixedAttemptTimeLimit(long duration, @Nonnull TimeUnit timeUnit, @Nonnull ExecutorService executorService) {
             this(SimpleTimeLimiter.create(executorService), duration, timeUnit);
         }
 

--- a/src/main/java/com/github/rholder/retry/BlockStrategies.java
+++ b/src/main/java/com/github/rholder/retry/BlockStrategies.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012-2015 Ray Holder
+ * Modifications copyright 2017 Robert Huffman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +22,7 @@ import javax.annotation.concurrent.Immutable;
 /**
  * Factory class for {@link BlockStrategy} instances.
  */
+@SuppressWarnings("WeakerAccess")
 public final class BlockStrategies {
 
     private static final BlockStrategy THREAD_SLEEP_STRATEGY = new ThreadSleepStrategy();

--- a/src/main/java/com/github/rholder/retry/RetryException.java
+++ b/src/main/java/com/github/rholder/retry/RetryException.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012-2015 Ray Holder
+ * Modifications copyright 2017 Robert Huffman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author JB
  */
+@SuppressWarnings("WeakerAccess")
 @Immutable
 public final class RetryException extends Exception {
 
@@ -41,7 +43,7 @@ public final class RetryException extends Exception {
      * @param numberOfFailedAttempts times we've tried and failed
      * @param lastFailedAttempt      what happened the last time we failed
      */
-    public RetryException(int numberOfFailedAttempts, @Nonnull Attempt<?> lastFailedAttempt) {
+    RetryException(int numberOfFailedAttempts, @Nonnull Attempt<?> lastFailedAttempt) {
         this("Retrying failed to complete successfully after " + numberOfFailedAttempts + " attempts.", numberOfFailedAttempts, lastFailedAttempt);
     }
 
@@ -53,7 +55,7 @@ public final class RetryException extends Exception {
      * @param numberOfFailedAttempts times we've tried and failed
      * @param lastFailedAttempt      what happened the last time we failed
      */
-    public RetryException(String message, int numberOfFailedAttempts, Attempt<?> lastFailedAttempt) {
+    private RetryException(String message, int numberOfFailedAttempts, Attempt<?> lastFailedAttempt) {
         super(message, checkNotNull(lastFailedAttempt, "Last attempt was null").hasException() ? lastFailedAttempt.getExceptionCause() : null);
         this.numberOfFailedAttempts = numberOfFailedAttempts;
         this.lastFailedAttempt = lastFailedAttempt;

--- a/src/main/java/com/github/rholder/retry/StopStrategies.java
+++ b/src/main/java/com/github/rholder/retry/StopStrategies.java
@@ -41,6 +41,7 @@ public final class StopStrategies {
      *
      * @return a stop strategy which never stops
      */
+    @SuppressWarnings("WeakerAccess")
     public static StopStrategy neverStop() {
         return NEVER_STOP;
     }
@@ -51,6 +52,7 @@ public final class StopStrategies {
      * @param attemptNumber the number of failed attempts before stopping
      * @return a stop strategy which stops after {@code attemptNumber} attempts
      */
+    @SuppressWarnings("WeakerAccess")
     public static StopStrategy stopAfterAttempt(int attemptNumber) {
         return new StopAfterAttemptStrategy(attemptNumber);
     }
@@ -82,6 +84,7 @@ public final class StopStrategies {
      * @param timeUnit the unit of the duration
      * @return a stop strategy which stops after {@code delayInMillis} time in milliseconds
      */
+    @SuppressWarnings("WeakerAccess")
     public static StopStrategy stopAfterDelay(long duration, @Nonnull TimeUnit timeUnit) {
         Preconditions.checkNotNull(timeUnit, "The time unit may not be null");
         return new StopAfterDelayStrategy(timeUnit.toMillis(duration));
@@ -99,7 +102,7 @@ public final class StopStrategies {
     private static final class StopAfterAttemptStrategy implements StopStrategy {
         private final int maxAttemptNumber;
 
-        public StopAfterAttemptStrategy(int maxAttemptNumber) {
+        StopAfterAttemptStrategy(int maxAttemptNumber) {
             Preconditions.checkArgument(maxAttemptNumber >= 1, "maxAttemptNumber must be >= 1 but is %d", maxAttemptNumber);
             this.maxAttemptNumber = maxAttemptNumber;
         }
@@ -114,7 +117,7 @@ public final class StopStrategies {
     private static final class StopAfterDelayStrategy implements StopStrategy {
         private final long maxDelay;
 
-        public StopAfterDelayStrategy(long maxDelay) {
+        StopAfterDelayStrategy(long maxDelay) {
             Preconditions.checkArgument(maxDelay >= 0L, "maxDelay must be >= 0 but is %d", maxDelay);
             this.maxDelay = maxDelay;
         }

--- a/src/main/java/com/github/rholder/retry/WaitStrategies.java
+++ b/src/main/java/com/github/rholder/retry/WaitStrategies.java
@@ -17,7 +17,6 @@
 
 package com.github.rholder.retry;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -26,12 +25,14 @@ import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * Factory class for instances of {@link WaitStrategy}.
  *
  * @author JB
  */
+@SuppressWarnings("WeakerAccess")
 public final class WaitStrategies {
 
   private static final WaitStrategy NO_WAIT_STRATEGY = new FixedWaitStrategy(0L);
@@ -214,7 +215,7 @@ public final class WaitStrategies {
                                                                  @Nonnull Function<T, Long> function) {
     Preconditions.checkNotNull(exceptionClass, "exceptionClass may not be null");
     Preconditions.checkNotNull(function, "function may not be null");
-    return new ExceptionWaitStrategy<T>(exceptionClass, function);
+    return new ExceptionWaitStrategy<>(exceptionClass, function);
   }
 
   /**
@@ -235,7 +236,7 @@ public final class WaitStrategies {
   private static final class FixedWaitStrategy implements WaitStrategy {
     private final long sleepTime;
 
-    public FixedWaitStrategy(long sleepTime) {
+    FixedWaitStrategy(long sleepTime) {
       Preconditions.checkArgument(sleepTime >= 0L, "sleepTime must be >= 0 but is %d", sleepTime);
       this.sleepTime = sleepTime;
     }
@@ -252,7 +253,7 @@ public final class WaitStrategies {
     private final long minimum;
     private final long maximum;
 
-    public RandomWaitStrategy(long minimum, long maximum) {
+    RandomWaitStrategy(long minimum, long maximum) {
       Preconditions.checkArgument(minimum >= 0, "minimum must be >= 0 but is %d", minimum);
       Preconditions.checkArgument(maximum > minimum, "maximum must be > minimum but maximum is %d and minimum is", maximum, minimum);
 
@@ -272,8 +273,8 @@ public final class WaitStrategies {
     private final long initialSleepTime;
     private final long increment;
 
-    public IncrementingWaitStrategy(long initialSleepTime,
-                                    long increment) {
+    IncrementingWaitStrategy(long initialSleepTime,
+                             long increment) {
       Preconditions.checkArgument(initialSleepTime >= 0L, "initialSleepTime must be >= 0 but is %d", initialSleepTime);
       this.initialSleepTime = initialSleepTime;
       this.increment = increment;
@@ -291,8 +292,8 @@ public final class WaitStrategies {
     private final long multiplier;
     private final long maximumWait;
 
-    public ExponentialWaitStrategy(long multiplier,
-                                   long maximumWait) {
+    ExponentialWaitStrategy(long multiplier,
+                            long maximumWait) {
       Preconditions.checkArgument(multiplier > 0L, "multiplier must be > 0 but is %d", multiplier);
       Preconditions.checkArgument(maximumWait >= 0L, "maximumWait must be >= 0 but is %d", maximumWait);
       Preconditions.checkArgument(multiplier < maximumWait, "multiplier must be < maximumWait but is %d", multiplier);
@@ -316,7 +317,7 @@ public final class WaitStrategies {
     private final long multiplier;
     private final long maximumWait;
 
-    public FibonacciWaitStrategy(long multiplier, long maximumWait) {
+    FibonacciWaitStrategy(long multiplier, long maximumWait) {
       Preconditions.checkArgument(multiplier > 0L, "multiplier must be > 0 but is %d", multiplier);
       Preconditions.checkArgument(maximumWait >= 0L, "maximumWait must be >= 0 but is %d", maximumWait);
       Preconditions.checkArgument(multiplier < maximumWait, "multiplier must be < maximumWait but is %d", multiplier);
@@ -358,7 +359,7 @@ public final class WaitStrategies {
   private static final class CompositeWaitStrategy implements WaitStrategy {
     private final List<WaitStrategy> waitStrategies;
 
-    public CompositeWaitStrategy(List<WaitStrategy> waitStrategies) {
+    CompositeWaitStrategy(List<WaitStrategy> waitStrategies) {
       Preconditions.checkState(!waitStrategies.isEmpty(), "Need at least one wait strategy");
       this.waitStrategies = waitStrategies;
     }
@@ -378,7 +379,7 @@ public final class WaitStrategies {
     private final Class<T> exceptionClass;
     private final Function<T, Long> function;
 
-    public ExceptionWaitStrategy(@Nonnull Class<T> exceptionClass, @Nonnull Function<T, Long> function) {
+    ExceptionWaitStrategy(@Nonnull Class<T> exceptionClass, @Nonnull Function<T, Long> function) {
       this.exceptionClass = exceptionClass;
       this.function = function;
     }

--- a/src/test/java/com/github/rholder/retry/AttemptTimeLimiterTest.java
+++ b/src/test/java/com/github/rholder/retry/AttemptTimeLimiterTest.java
@@ -30,8 +30,8 @@ import java.util.concurrent.TimeoutException;
  */
 public class AttemptTimeLimiterTest {
 
-    Retryer<Void> r = RetryerBuilder.<Void>newBuilder()
-            .withAttemptTimeLimiter(AttemptTimeLimiters.<Void>fixedTimeLimit(1, TimeUnit.SECONDS))
+    private final Retryer<Void> r = RetryerBuilder.<Void>newBuilder()
+            .withAttemptTimeLimiter(AttemptTimeLimiters.fixedTimeLimit(1, TimeUnit.SECONDS))
             .build();
 
     @Test

--- a/src/test/java/com/github/rholder/retry/RetryerBuilderTest.java
+++ b/src/test/java/com/github/rholder/retry/RetryerBuilderTest.java
@@ -402,32 +402,6 @@ public class RetryerBuilderTest {
     }
 
     @Test
-    public void testWhetherBuilderFailsForNullStopStrategy() {
-        try {
-            //noinspection ConstantConditions
-            RetryerBuilder.<Void>newBuilder()
-                    .withStopStrategy(null)
-                    .build();
-            fail("Exepcted to fail for null stop strategy");
-        } catch (NullPointerException exception) {
-            assertTrue(exception.getMessage().contains("stopStrategy may not be null"));
-        }
-    }
-
-    @Test
-    public void testWhetherBuilderFailsForNullWaitStrategy() {
-        try {
-            //noinspection ConstantConditions
-            RetryerBuilder.<Void>newBuilder()
-                    .withWaitStrategy(null)
-                    .build();
-            fail("Exepcted to fail for null wait strategy");
-        } catch (NullPointerException exception) {
-            assertTrue(exception.getMessage().contains("waitStrategy may not be null"));
-        }
-    }
-
-    @Test
     public void testWhetherBuilderFailsForNullWaitStrategyWithCompositeStrategies() {
         try {
             RetryerBuilder.<Void>newBuilder()

--- a/src/test/java/com/github/rholder/retry/RetryerBuilderTest.java
+++ b/src/test/java/com/github/rholder/retry/RetryerBuilderTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012-2015 Ray Holder
+ * Modifications copyright 2017 Robert Huffman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +18,12 @@
 package com.github.rholder.retry;
 
 import com.github.rholder.retry.Retryer.RetryerCallable;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -31,11 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class RetryerBuilderTest {
 
@@ -44,7 +40,7 @@ public class RetryerBuilderTest {
         Callable<Boolean> callable = notNullAfter5Attempts();
         Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
                 .withWaitStrategy(WaitStrategies.fixedWait(50L, TimeUnit.MILLISECONDS))
-                .retryIfResult(Predicates.<Boolean>isNull())
+                .retryIfResult(Objects::isNull)
                 .build();
         long start = System.currentTimeMillis();
         boolean result = retryer.call(callable);
@@ -59,7 +55,7 @@ public class RetryerBuilderTest {
                 .withWaitStrategy(WaitStrategies.join(
                         WaitStrategies.fixedWait(50L, TimeUnit.MILLISECONDS),
                         WaitStrategies.fibonacciWait(10, Long.MAX_VALUE, TimeUnit.MILLISECONDS)))
-                .retryIfResult(Predicates.<Boolean>isNull())
+                .retryIfResult(Objects::isNull)
                 .build();
         long start = System.currentTimeMillis();
         boolean result = retryer.call(callable);
@@ -74,7 +70,7 @@ public class RetryerBuilderTest {
                 .withWaitStrategy(WaitStrategies.join(
                         WaitStrategies.incrementingWait(10L, TimeUnit.MILLISECONDS, 10L, TimeUnit.MILLISECONDS),
                         WaitStrategies.fibonacciWait(10, Long.MAX_VALUE, TimeUnit.MILLISECONDS)))
-                .retryIfResult(Predicates.<Boolean>isNull())
+                .retryIfResult(Objects::isNull)
                 .build();
         long start = System.currentTimeMillis();
         boolean result = retryer.call(callable);
@@ -102,7 +98,7 @@ public class RetryerBuilderTest {
         Callable<Boolean> callable = notNullAfter5Attempts();
         Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
                 .withStopStrategy(StopStrategies.stopAfterAttempt(3))
-                .retryIfResult(Predicates.<Boolean>isNull())
+                .retryIfResult(Objects::isNull)
                 .build();
         try {
             retryer.call(callable);
@@ -116,16 +112,11 @@ public class RetryerBuilderTest {
     public void testWithBlockStrategy() throws ExecutionException, RetryException {
         Callable<Boolean> callable = notNullAfter5Attempts();
         final AtomicInteger counter = new AtomicInteger();
-        BlockStrategy blockStrategy = new BlockStrategy() {
-            @Override
-            public void block(long sleepTime) throws InterruptedException {
-                counter.incrementAndGet();
-            }
-        };
+        BlockStrategy blockStrategy = sleepTime -> counter.incrementAndGet();
 
         Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
                 .withBlockStrategy(blockStrategy)
-                .retryIfResult(Predicates.<Boolean>isNull())
+                .retryIfResult(Objects::isNull)
                 .build();
         final int retryCount = 5;
         boolean result = retryer.call(callable);
@@ -271,12 +262,7 @@ public class RetryerBuilderTest {
     public void testRetryIfExceptionWithPredicate() throws RetryException, ExecutionException {
         Callable<Boolean> callable = noIOExceptionAfter5Attempts();
         Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
-                .retryIfException(new Predicate<Throwable>() {
-                    @Override
-                    public boolean apply(Throwable t) {
-                        return t instanceof IOException;
-                    }
-                })
+                .retryIfException(t -> t instanceof IOException)
                 .build();
         assertTrue(retryer.call(callable));
 
@@ -290,12 +276,7 @@ public class RetryerBuilderTest {
 
         callable = noIOExceptionAfter5Attempts();
         retryer = RetryerBuilder.<Boolean>newBuilder()
-                .retryIfException(new Predicate<Throwable>() {
-                    @Override
-                    public boolean apply(Throwable t) {
-                        return t instanceof IOException;
-                    }
-                })
+                .retryIfException(t -> t instanceof IOException)
                 .withStopStrategy(StopStrategies.stopAfterAttempt(3))
                 .build();
         try {
@@ -313,13 +294,13 @@ public class RetryerBuilderTest {
     public void testRetryIfResult() throws ExecutionException, RetryException {
         Callable<Boolean> callable = notNullAfter5Attempts();
         Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
-                .retryIfResult(Predicates.<Boolean>isNull())
+                .retryIfResult(Objects::isNull)
                 .build();
         assertTrue(retryer.call(callable));
 
         callable = notNullAfter5Attempts();
         retryer = RetryerBuilder.<Boolean>newBuilder()
-                .retryIfResult(Predicates.<Boolean>isNull())
+                .retryIfResult(Objects::isNull)
                 .withStopStrategy(StopStrategies.stopAfterAttempt(3))
                 .build();
         try {
@@ -337,7 +318,7 @@ public class RetryerBuilderTest {
     public void testMultipleRetryConditions() throws ExecutionException, RetryException {
         Callable<Boolean> callable = notNullResultOrIOExceptionOrRuntimeExceptionAfter5Attempts();
         Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
-                .retryIfResult(Predicates.<Boolean>isNull())
+                .retryIfResult(Objects::isNull)
                 .retryIfExceptionOfType(IOException.class)
                 .retryIfRuntimeException()
                 .withStopStrategy(StopStrategies.stopAfterAttempt(3))
@@ -353,7 +334,7 @@ public class RetryerBuilderTest {
 
         callable = notNullResultOrIOExceptionOrRuntimeExceptionAfter5Attempts();
         retryer = RetryerBuilder.<Boolean>newBuilder()
-                .retryIfResult(Predicates.<Boolean>isNull())
+                .retryIfResult(Objects::isNull)
                 .retryIfExceptionOfType(IOException.class)
                 .retryIfRuntimeException()
                 .build();
@@ -385,24 +366,21 @@ public class RetryerBuilderTest {
     public void testInterruption() throws InterruptedException, ExecutionException {
         final AtomicBoolean result = new AtomicBoolean(false);
         final CountDownLatch latch = new CountDownLatch(1);
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
-                        .withWaitStrategy(WaitStrategies.fixedWait(1000L, TimeUnit.MILLISECONDS))
-                        .retryIfResult(Predicates.<Boolean>isNull())
-                        .build();
-                try {
-                    retryer.call(alwaysNull(latch));
-                    fail("RetryException expected");
-                } catch (RetryException e) {
-                    assertTrue(!e.getLastFailedAttempt().hasException());
-                    assertNull(e.getCause());
-                    assertTrue(Thread.currentThread().isInterrupted());
-                    result.set(true);
-                } catch (ExecutionException e) {
-                    fail("RetryException expected");
-                }
+        Runnable r = () -> {
+            Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
+                    .withWaitStrategy(WaitStrategies.fixedWait(1000L, TimeUnit.MILLISECONDS))
+                    .retryIfResult(Objects::isNull)
+                    .build();
+            try {
+                retryer.call(alwaysNull(latch));
+                fail("RetryException expected");
+            } catch (RetryException e) {
+                assertTrue(!e.getLastFailedAttempt().hasException());
+                assertNull(e.getCause());
+                assertTrue(Thread.currentThread().isInterrupted());
+                result.set(true);
+            } catch (ExecutionException e) {
+                fail("RetryException expected");
             }
         };
         Thread t = new Thread(r);
@@ -417,7 +395,7 @@ public class RetryerBuilderTest {
     public void testWrap() throws ExecutionException, RetryException {
         Callable<Boolean> callable = notNullAfter5Attempts();
         Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
-                .retryIfResult(Predicates.<Boolean>isNull())
+                .retryIfResult(Objects::isNull)
                 .build();
         RetryerCallable<Boolean> wrapped = retryer.wrap(callable);
         assertTrue(wrapped.call());
@@ -426,6 +404,7 @@ public class RetryerBuilderTest {
     @Test
     public void testWhetherBuilderFailsForNullStopStrategy() {
         try {
+            //noinspection ConstantConditions
             RetryerBuilder.<Void>newBuilder()
                     .withStopStrategy(null)
                     .build();
@@ -438,6 +417,7 @@ public class RetryerBuilderTest {
     @Test
     public void testWhetherBuilderFailsForNullWaitStrategy() {
         try {
+            //noinspection ConstantConditions
             RetryerBuilder.<Void>newBuilder()
                     .withWaitStrategy(null)
                     .build();
@@ -461,7 +441,7 @@ public class RetryerBuilderTest {
 
     @Test
     public void testRetryListener_SuccessfulAttempt() throws Exception {
-        final Map<Long, Attempt> attempts = new HashMap<Long, Attempt>();
+        final Map<Long, Attempt> attempts = new HashMap<>();
 
         RetryListener listener = new RetryListener() {
             @Override
@@ -473,24 +453,24 @@ public class RetryerBuilderTest {
         Callable<Boolean> callable = notNullAfter5Attempts();
 
         Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
-                .retryIfResult(Predicates.<Boolean>isNull())
+                .retryIfResult(Objects::isNull)
                 .withRetryListener(listener)
                 .build();
         assertTrue(retryer.call(callable));
 
         assertEquals(6, attempts.size());
 
-        assertResultAttempt(attempts.get(1L), true, null);
-        assertResultAttempt(attempts.get(2L), true, null);
-        assertResultAttempt(attempts.get(3L), true, null);
-        assertResultAttempt(attempts.get(4L), true, null);
-        assertResultAttempt(attempts.get(5L), true, null);
-        assertResultAttempt(attempts.get(6L), true, true);
+        assertResultAttempt(attempts.get(1L), null);
+        assertResultAttempt(attempts.get(2L), null);
+        assertResultAttempt(attempts.get(3L), null);
+        assertResultAttempt(attempts.get(4L), null);
+        assertResultAttempt(attempts.get(5L), null);
+        assertResultAttempt(attempts.get(6L), true);
     }
 
     @Test
     public void testRetryListener_WithException() throws Exception {
-        final Map<Long, Attempt> attempts = new HashMap<Long, Attempt>();
+        final Map<Long, Attempt> attempts = new HashMap<>();
 
         RetryListener listener = new RetryListener() {
             @Override
@@ -502,7 +482,7 @@ public class RetryerBuilderTest {
         Callable<Boolean> callable = noIOExceptionAfter5Attempts();
 
         Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
-                .retryIfResult(Predicates.<Boolean>isNull())
+                .retryIfResult(Objects::isNull)
                 .retryIfException()
                 .withRetryListener(listener)
                 .build();
@@ -510,22 +490,17 @@ public class RetryerBuilderTest {
 
         assertEquals(6, attempts.size());
 
-        assertExceptionAttempt(attempts.get(1L), true, IOException.class);
-        assertExceptionAttempt(attempts.get(2L), true, IOException.class);
-        assertExceptionAttempt(attempts.get(3L), true, IOException.class);
-        assertExceptionAttempt(attempts.get(4L), true, IOException.class);
-        assertExceptionAttempt(attempts.get(5L), true, IOException.class);
-        assertResultAttempt(attempts.get(6L), true, true);
+        assertExceptionAttempt(attempts.get(1L), IOException.class);
+        assertExceptionAttempt(attempts.get(2L), IOException.class);
+        assertExceptionAttempt(attempts.get(3L), IOException.class);
+        assertExceptionAttempt(attempts.get(4L), IOException.class);
+        assertExceptionAttempt(attempts.get(5L), IOException.class);
+        assertResultAttempt(attempts.get(6L), true);
     }
 
     @Test
     public void testMultipleRetryListeners() throws Exception {
-        Callable<Boolean> callable = new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                return true;
-            }
-        };
+        Callable<Boolean> callable = () -> true;
 
         final AtomicBoolean listenerOne = new AtomicBoolean(false);
         final AtomicBoolean listenerTwo = new AtomicBoolean(false);
@@ -550,25 +525,22 @@ public class RetryerBuilderTest {
         assertTrue(listenerTwo.get());
     }
 
-    private void assertResultAttempt(Attempt actualAttempt, boolean expectedHasResult, Object expectedResult) {
+    private void assertResultAttempt(Attempt actualAttempt, Object expectedResult) {
         assertFalse(actualAttempt.hasException());
-        assertEquals(expectedHasResult, actualAttempt.hasResult());
+        assertTrue(actualAttempt.hasResult());
         assertEquals(expectedResult, actualAttempt.getResult());
     }
 
-    private void assertExceptionAttempt(Attempt actualAttempt, boolean expectedHasException, Class<?> expectedExceptionClass) {
+    private void assertExceptionAttempt(Attempt actualAttempt, Class<?> expectedExceptionClass) {
         assertFalse(actualAttempt.hasResult());
-        assertEquals(expectedHasException, actualAttempt.hasException());
+        assertTrue(actualAttempt.hasException());
         assertTrue(expectedExceptionClass.isInstance(actualAttempt.getExceptionCause()));
     }
 
     private Callable<Boolean> alwaysNull(final CountDownLatch latch) {
-        return new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                latch.countDown();
-                return null;
-            }
+        return () -> {
+            latch.countDown();
+            return null;
         };
     }
 }

--- a/src/test/java/com/github/rholder/retry/StopStrategiesTest.java
+++ b/src/test/java/com/github/rholder/retry/StopStrategiesTest.java
@@ -56,7 +56,7 @@ public class StopStrategiesTest {
         assertTrue(StopStrategies.stopAfterDelay(1, TimeUnit.SECONDS).shouldStop(failedAttempt(2, 1001L)));
     }
 
-    public Attempt<Boolean> failedAttempt(long attemptNumber, long delaySinceFirstAttempt) {
-        return new Retryer.ExceptionAttempt<Boolean>(new RuntimeException(), attemptNumber, delaySinceFirstAttempt);
+    private Attempt<Boolean> failedAttempt(long attemptNumber, long delaySinceFirstAttempt) {
+        return new Retryer.ExceptionAttempt<>(new RuntimeException(), attemptNumber, delaySinceFirstAttempt);
     }
 }


### PR DESCRIPTION
Update to Java 8 idioms and remove warnings that show up in Intellij.

This includes:
- replacing the Guava Predicate and Function usages with standard Java Predicate and Function classes
- removing unnecessary generic type declarations
- restricting access to some methods
- adding @Suppress annotation for methods and classes that are not used in the code but must be public for the library to be used
- replacing anonymous inner classes (Callables, Runnables, and Predicates) with Java 8 lambdas

Fixes #15 