### PR TITLE
Make cached thread pool static

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,8 +103,10 @@ dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:2.0.2'
 
     // junit testing
-    testCompile 'junit:junit:4.11'
+    testCompile 'junit:junit-dep:4.11'
     testCompile 'org.mockito:mockito-all:1.9.5'
+    testCompile 'org.hamcrest:hamcrest-core:1.3'
+    testCompile 'org.hamcrest:hamcrest-library:1.3'
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/build.gradle
+++ b/build.gradle
@@ -103,10 +103,8 @@ dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:2.0.2'
 
     // junit testing
-    testCompile 'junit:junit-dep:4.11'
+    testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-all:1.9.5'
-    testCompile 'org.hamcrest:hamcrest-core:1.3'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/com/github/rholder/retry/AttemptTimeLimiters.java
+++ b/src/main/java/com/github/rholder/retry/AttemptTimeLimiters.java
@@ -48,9 +48,12 @@ public class AttemptTimeLimiters {
     }
 
     /**
-     * For control over thread management, it is preferable to offer an {@link ExecutorService} through the other
-     * factory method, {@link #fixedTimeLimit(long, TimeUnit, ExecutorService)}. See the note on
-     * {@link SimpleTimeLimiter#SimpleTimeLimiter(ExecutorService)}, which this AttemptTimeLimiter uses.
+     * For control over thread management, it is preferable to offer an {@link ExecutorService}
+     * through the other factory method, {@link #fixedTimeLimit(long, TimeUnit, ExecutorService)}.
+     * All calls to this method use the same cached thread pool created by
+     * {@link Executors#newCachedThreadPool()}. It is unbounded, meaning there is no limit to
+     * the number of threads it will create. It will reuse idle threads if they are available,
+     * and idle threads remain alive for 60 seconds.
      *
      * @param duration that an attempt may persist before being circumvented
      * @param timeUnit of the 'duration' arg
@@ -85,12 +88,17 @@ public class AttemptTimeLimiters {
     @Immutable
     private static final class FixedAttemptTimeLimit<V> implements AttemptTimeLimiter<V> {
 
+        /**
+         * ExecutorService used when no ExecutorService is specified in the constructor
+         */
+        private static final ExecutorService defaultExecutorService = Executors.newCachedThreadPool();
+
         private final TimeLimiter timeLimiter;
         private final long duration;
         private final TimeUnit timeUnit;
 
         FixedAttemptTimeLimit(long duration, @Nonnull TimeUnit timeUnit) {
-            this(duration, timeUnit, Executors.newCachedThreadPool());
+            this(duration, timeUnit, defaultExecutorService);
         }
 
         FixedAttemptTimeLimit(long duration, @Nonnull TimeUnit timeUnit, @Nonnull ExecutorService executorService) {

--- a/src/test/java/com/github/rholder/retry/AttemptTimeLimitersTest.java
+++ b/src/test/java/com/github/rholder/retry/AttemptTimeLimitersTest.java
@@ -8,8 +8,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertTrue;
 
 /*
  * Copyright ${year} Robert Huffman
@@ -26,21 +25,24 @@ import static org.hamcrest.Matchers.lessThan;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-public class FixedAttemptTimeLimitTest {
+public class AttemptTimeLimitersTest {
 
     @Test
-    public void testFixedTimeLimitWithNoExeuctorReusesThreads() throws Exception {
-        AttemptTimeLimiter<Void> timeLimiter = AttemptTimeLimiters.fixedTimeLimit(1, TimeUnit.SECONDS);
+    public void testFixedTimeLimitWithNoExecutorReusesThreads() throws Exception {
         Set<Long> threadsUsed = Collections.synchronizedSet(Sets.newHashSet());
         Callable<Void> callable = () -> {
             threadsUsed.add(Thread.currentThread().getId());
             return null;
         };
+
         int iterations = 20;
         for (int i = 0; i < iterations; i++) {
+            AttemptTimeLimiter<Void> timeLimiter =
+                AttemptTimeLimiters.fixedTimeLimit(1, TimeUnit.SECONDS);
             timeLimiter.call(callable);
         }
-        assertThat(threadsUsed.size(), lessThan(iterations));
+        assertTrue("Should have used less than " + iterations +
+            " threads", threadsUsed.size() < iterations);
     }
 
 }

--- a/src/test/java/com/github/rholder/retry/FixedAttemptTimeLimitTest.java
+++ b/src/test/java/com/github/rholder/retry/FixedAttemptTimeLimitTest.java
@@ -1,0 +1,46 @@
+package com.github.rholder.retry;
+
+import com.google.common.collect.Sets;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+
+/*
+ * Copyright ${year} Robert Huffman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class FixedAttemptTimeLimitTest {
+
+    @Test
+    public void testFixedTimeLimitWithNoExeuctorReusesThreads() throws Exception {
+        AttemptTimeLimiter<Void> timeLimiter = AttemptTimeLimiters.fixedTimeLimit(1, TimeUnit.SECONDS);
+        Set<Long> threadsUsed = Collections.synchronizedSet(Sets.newHashSet());
+        Callable<Void> callable = () -> {
+            threadsUsed.add(Thread.currentThread().getId());
+            return null;
+        };
+        int iterations = 20;
+        for (int i = 0; i < iterations; i++) {
+            timeLimiter.call(callable);
+        }
+        assertThat(threadsUsed.size(), lessThan(iterations));
+    }
+
+}


### PR DESCRIPTION
Use static instance of cached thread pool in FixedAttemptTimeLimit

There is no need for the FixedAttemptTimeLimit that takes no executor
to create a new cached thread pool every time it is invoked. Instead,
all instances can use the same static cached thread pool so threads
are reused.

Fixes #17
