### PR TITLE
Handle InterruptedExceptions thrown from Callable

### DIFF
--- a/src/main/java/com/github/rholder/retry/Retryer.java
+++ b/src/main/java/com/github/rholder/retry/Retryer.java
@@ -98,6 +98,8 @@ public final class Retryer {
             try {
                 T result = attemptTimeLimiter.call(callable);
                 attempt = new Attempt<>(result, attemptNumber, System.currentTimeMillis() - startTimeMillis);
+            } catch(InterruptedException e) {
+                throw e;
             } catch (Throwable t) {
                 attempt = new Attempt<>(t, attemptNumber, System.currentTimeMillis() - startTimeMillis);
             }


### PR DESCRIPTION
Fixes #36: InterruptedException thrown by a Callable is not handled correctly

If he Callable throws an exception it is now simply thrown immediately. Note this means you cannot have a retry strategy that retries on an InterruptedException.

(I should probably make it impossible to build such a retry strategy.)